### PR TITLE
Separate CO2 emissions to sectors

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -36,8 +36,8 @@ export function co2Rating(game: Game): number {
   if (game.values.co2emissions === 0) {
     return 100 // nothing is better than no emissions!
   }
-  // the year's budget should be only a small part of the remaining total budget
-  const yearBudget = game.values.co2budget * defaultValues.co2emissions / defaultValues.co2budget
+  // the year's budget should be only a part of the remaining total budget
+  const yearBudget = game.values.co2budget * defaultValues.co2emissions / defaultValues.co2budget * 0.8
   // the ratio of actual emissions to the yearly budget: < 1 is bad, > 1 is good
   const ratio = yearBudget / game.values.co2emissions
   return clampToPercent(ratio * 50)

--- a/src/laws/Kohleverstromung.ts
+++ b/src/laws/Kohleverstromung.ts
@@ -20,7 +20,6 @@ export default {
       stateDebt: -compensation + subventions,
       unemployment: jobs,
       electricityCoal: -data.electricityCoal,
-      electricityGas: data.electricityGas + data.electricityCoal,
     }
   },
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -8,7 +8,7 @@ export const defaultValues = {
   popularity: 50, // 50% of all people accept you as your chancellor
 
   // hidden
-  co2emissions: 805, // in 2019, source https://www.bundesregierung.de/breg-de/aktuelles/bilanz-umweltbundesamt-1730880
+  co2emissions: 739, // in 2020, source https://www.bmu.de/pressemitteilung/treibhausgasemissionen-sinken-2020-um-87-prozent/
   unemployment: 2695, // in 2020, source https://www.arbeitsagentur.de/news/arbeitsmarkt-vorjahre
   gdp: 3332, // in 2020, source http://www.statistikportal.de/de/bruttoinlandsprodukt-vgr
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -19,7 +19,14 @@ export const defaultValues = {
   electricityWater: 18.4,
   electricityCoal: 117.72,
   electricityBiomass: 47.15,
-  electricityNuclear: 60.92
+  electricityNuclear: 60.92,
+
+  // 2020, https://www.umweltbundesamt.de/daten/klima/treibhausgas-emissionen-in-deutschland#nationale-und-europaische-klimaziele
+  co2emissionsIndustry: 186,
+  co2emissionsBuildings: 118,
+  co2emissionsMobility: 150,
+  co2emissionsAgriculture: 70,
+  co2emissionsOthers: 9
 }
 
 const initialGame = {
@@ -43,6 +50,20 @@ export function createBaseValues(values: WritableBaseParams): BaseParams {
         this.electricityCoal -
         this.electricityBiomass -
         this.electricityNuclear
+      )
+    },
+
+    get co2emissionsEnergy(): number {
+      return this.electricityCoal + this.electricityGas * 0.399 // should sum up to 280 in 2020
+    },
+
+    get co2emissions(): number {
+      return (
+        this.co2emissionsEnergy +
+        this.co2emissionsIndustry +
+        this.co2emissionsMobility +
+        this.co2emissionsBuildings +
+        this.co2emissionsOthers
       )
     }
   }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -42,7 +42,11 @@ export function createBaseValues(values: WritableBaseParams): BaseParams {
   return {
     ...values,
 
-    get electricityGas(): number {
+    get electricityCoal() {
+      return this.electricityHardCoal + this.electricityBrownCoal
+    },
+
+    get electricityGas() {
       return (
         this.electricityDemand -
         this.electricitySolar -
@@ -55,11 +59,17 @@ export function createBaseValues(values: WritableBaseParams): BaseParams {
       )
     },
 
-    get co2emissionsEnergy(): number {
+    get co2emissionsEnergy() {
       // should sum up to 220 in 2020
-      return this.electricityHardCoal * 0.835 +
+      // factors from https://www.rensmart.com/Calculators/KWH-to-CO2 and @thomas-olszamowski
+      return this.electricityGas * 0.399 +
+        this.electricitySolar * 0.058 +
+        this.electricityWind * 0.005 +
+        this.electricityWater * 0.02 +
+        this.electricityHardCoal * 0.835 +
         this.electricityBrownCoal * 1.137 +
-        this.electricityGas * 0.399
+        this.electricityBiomass * 0 + // TODO find correct factor (no source found)
+        this.electricityNuclear * 0.005
     },
 
     get co2emissions(): number {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -17,7 +17,8 @@ export const defaultValues = {
   electricitySolar: 51.42,
   electricityWind: 131.85,
   electricityWater: 18.4,
-  electricityCoal: 117.72,
+  electricityHardCoal: 35.46,
+  electricityBrownCoal: 82.13,
   electricityBiomass: 47.15,
   electricityNuclear: 60.92,
 
@@ -47,14 +48,18 @@ export function createBaseValues(values: WritableBaseParams): BaseParams {
         this.electricitySolar -
         this.electricityWind -
         this.electricityWater -
-        this.electricityCoal -
+        this.electricityHardCoal -
+        this.electricityBrownCoal -
         this.electricityBiomass -
         this.electricityNuclear
       )
     },
 
     get co2emissionsEnergy(): number {
-      return this.electricityCoal + this.electricityGas * 0.399 // should sum up to 280 in 2020
+      // should sum up to 220 in 2020
+      return this.electricityHardCoal * 0.835 +
+        this.electricityBrownCoal * 1.137 +
+        this.electricityGas * 0.399
     },
 
     get co2emissions(): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,8 @@ export type WritableBaseParams = {
   electricitySolar: TWh
   electricityWind: TWh
   electricityWater: TWh
-  electricityCoal: TWh
+  electricityHardCoal: TWh
+  electricityBrownCoal: TWh
   electricityBiomass: TWh
   electricityNuclear: TWh
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type WritableBaseParams = {
 }
 
 export type BaseParams = WritableBaseParams & {
+  electricityCoal: TWh
   electricityGas: TWh
   co2emissionsEnergy: MioTons
   co2emissions: MioTons

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export type WritableBaseParams = {
   stateDebt: MrdEuro
   popularity: Percent
 
-  co2emissions: MioTons
   unemployment: TsdPeople
   gdp: MrdEuro
 
@@ -23,10 +22,18 @@ export type WritableBaseParams = {
   electricityCoal: TWh
   electricityBiomass: TWh
   electricityNuclear: TWh
+
+  co2emissionsIndustry: MioTons
+  co2emissionsMobility: MioTons
+  co2emissionsBuildings: MioTons
+  co2emissionsAgriculture: MioTons
+  co2emissionsOthers: MioTons
 }
 
 export type BaseParams = WritableBaseParams & {
   electricityGas: TWh
+  co2emissionsEnergy: MioTons
+  co2emissions: MioTons
 }
 
 export type LawId = string

--- a/tests/Calculator.spec.ts
+++ b/tests/Calculator.spec.ts
@@ -44,7 +44,7 @@ describe("Calculator.applyEffects()", () => {
   it("should apply the effects to the game values")
 })
 
-const simpleGame: Game = {
+const initialGame: Game = {
   id: "1",
   values: createBaseValues(defaultValues),
   acceptedLaws: [],
@@ -55,38 +55,38 @@ const simpleGame: Game = {
 
 describe("Calculator.co2Rating", () => {
   it("should be nearly 50 in initial state", () => {
-    const rating = co2Rating({ ...simpleGame })
+    const rating = co2Rating({ ...initialGame })
     Math.round(rating / 10).should.equal(5)
   })
 
   it("should return 0 if budget is used up", () => {
-    const values = { ...simpleGame.values, co2budget: 0 }
-    const rating = co2Rating({ ...simpleGame, values })
+    const values = { ...initialGame.values, co2budget: 0 }
+    const rating = co2Rating({ ...initialGame, values })
     rating.should.equal(0)
   })
 
   it("should return 100 if no additional emissions are made", () => {
-    const values = { ...simpleGame.values, co2emissions: 0 }
-    const rating = co2Rating({ ...simpleGame, values })
+    const values = { ...initialGame.values, co2emissions: 0 }
+    const rating = co2Rating({ ...initialGame, values })
     rating.should.equal(100)
   })
 })
 
 describe("Calculator.financeRating", () => {
   it("should be nearly 50 for current debt", () => {
-    const rating = financeRating({ ...simpleGame })
+    const rating = financeRating({ ...initialGame })
     Math.round(rating / 10).should.equal(5)
   })
 
   it("should return 0 if debt is doubled", () => {
-    const values = { ...simpleGame.values, stateDebt: simpleGame.values.stateDebt * 2 }
-    const rating = financeRating({ ...simpleGame, values })
+    const values = { ...initialGame.values, stateDebt: initialGame.values.stateDebt * 2 }
+    const rating = financeRating({ ...initialGame, values })
     rating.should.equal(0)
   })
 
   it("should return 100 if there is no debt any more", () => {
-    const values = { ...simpleGame.values, stateDebt: 0 }
-    const rating = financeRating({ ...simpleGame, values })
+    const values = { ...initialGame.values, stateDebt: 0 }
+    const rating = financeRating({ ...initialGame, values })
     rating.should.equal(100)
   })
 })


### PR DESCRIPTION
Separated CO2 emissions for each sector (energy, industry, mobility, buildings and other), with the energy sector calculated from the electricity values we already had before.
This calculation does not yet work correctly, because it doesn't sum up to the actual CO2 values from this sector. This must be fixed before this PR can be merged.