### PR TITLE
Kernkraft

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,14 @@
         "<node_internals>/**"
       ],
       "type": "pwa-node"
+    },
+    {
+      "name": "Attach to Firefox",
+      "type": "firefox",
+      "request": "attach",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/frontend",
+
     }
   ]
 }

--- a/frontend/src/Calculator.ts
+++ b/frontend/src/Calculator.ts
@@ -1,4 +1,4 @@
-import { BaseParams, AcceptedLaw, Game, Event, Law } from "./types"
+import { BaseParams, AcceptedLaw, Game, LawReference } from "./types"
 import "should"
 import { defaultValues } from "./repository"
 
@@ -22,6 +22,10 @@ export function calculateNextYear(currentValues: BaseParams, laws: AcceptedLaw[]
   values.co2budget -= values.co2emissions
 
   return values
+}
+
+export function lawsForNextYear(currentValues: BaseParams, laws: AcceptedLaw[], year: number): LawReference[] {
+  return [{lawId: "ASDF", effectiveSince: 0}]
 }
 
 function clampToPercent(value: number) {

--- a/frontend/src/laws/InitialAtomausstieg.ts
+++ b/frontend/src/laws/InitialAtomausstieg.ts
@@ -3,7 +3,7 @@ import { createLaw } from "../Factory"
 export default createLaw({
   title: "Atomausstieg finded wie beschlossen 2022 statt",
   description: "",
-  labels: ["hidden", "initial"],
+  labels: ["hidden", "initial", "Kernenergie"],
 
   effects(data, startYear, currentYear) {
     const mapping: Record<number, number> = {

--- a/frontend/src/laws/KeineFoerderungFuerTierhaltung.ts
+++ b/frontend/src/laws/KeineFoerderungFuerTierhaltung.ts
@@ -1,0 +1,14 @@
+import { createLaw } from "../Factory"
+
+export default createLaw({
+  title: "Förderung für Tierhaltung abschaffen",
+  description: "Subventionen für Tierhaltung werden insgesamt eingestellt.",
+
+  effects(data, startYear, currentYear) {
+    return {
+      co2emmissions: -100,
+      stateDebt: -1000,
+      popularity: - data.popularity * 0.1,
+    }
+  },
+})

--- a/frontend/src/laws/KernenergieVerlaengern.ts
+++ b/frontend/src/laws/KernenergieVerlaengern.ts
@@ -2,11 +2,16 @@ import { createLaw } from "../Factory"
 
 export default createLaw({
   title: "Kernenergienutzung verlängern",
-  description: "Eigentlich bereits abgeschaltete Kernkraftwerke wieder in Betrieb nehmen und neue bauen.",
+  description:
+    "Die Kernkraftwerke wird erlaubt bis zum Ende ihres Lebenszyklus weiterzulaufen." +
+    " Die jetzt beschlossenen frühzeitigen Abschaltungen werden ausgesetzt." +
+    " Eigentlich bereits abgeschaltete Kernkraftwerke wieder in Betrieb nehmen und neue bauen.",
+  removeLawsWithLabels: ["Kernenergie"],
 
   effects(data, startYear, currentYear) {
     return {
       co2emmissions: -100,
+      
       stateDebt: 1000,
     }
   },

--- a/frontend/src/laws/KernenergieVerlaengern.ts
+++ b/frontend/src/laws/KernenergieVerlaengern.ts
@@ -1,18 +1,18 @@
 import { createLaw } from "../Factory"
+import { BaseParams, LawDefinition } from "../types"
 
 export default createLaw({
   title: "Kernenergienutzung verlängern",
-  description:
-    "Die Kernkraftwerke wird erlaubt bis zum Ende ihres Lebenszyklus weiterzulaufen." +
-    " Die jetzt beschlossenen frühzeitigen Abschaltungen werden ausgesetzt." +
-    " Eigentlich bereits abgeschaltete Kernkraftwerke wieder in Betrieb nehmen und neue bauen.",
+  description: "Kernkraftwerke länger nutzen, wieder in Betrieb nehmen und neu bauen.",
   removeLawsWithLabels: ["Kernenergie"],
 
   effects(data, startYear, currentYear) {
+    const subventions = 2500 // Mio €
+
     return {
-      co2emmissions: -100,
-      
-      stateDebt: 1000,
+      electricityNuclear: 104.3 - data.electricityNuclear,
+      stateDebt: subventions,
+      popularity: -data.popularity * 0.1,
     }
   },
 })

--- a/frontend/src/laws/index.ts
+++ b/frontend/src/laws/index.ts
@@ -3,11 +3,13 @@ import EnergiemixDurchMarktGeregelt from "./EnergiemixDurchMarktGeregelt"
 import KernenergieVerlaengern from "./KernenergieVerlaengern"
 import WindenergieSubventionieren from "./WindenergieSubventionieren"
 import InitialAtomausstieg from "./InitialAtomausstieg"
+import KeineFoerderungFuerTierhaltung from "./KeineFoerderungFuerTierhaltung"
 
 export const allLaws = [
   Kohleverstromung,
   EnergiemixDurchMarktGeregelt,
   KernenergieVerlaengern,
   WindenergieSubventionieren,
+  KeineFoerderungFuerTierhaltung,
   InitialAtomausstieg,
 ]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,12 +31,13 @@ export type BaseParams = WritableBaseParams & {
 
 export type LawId = string
 
-export type LawLabel = "hidden" | "initial"
+export type LawLabel = "hidden" | "initial" | "Kernenergie"
 
 export type LawDefinition = {
   title: string
   description: string
   labels?: LawLabel[]
+  removeLawsWithLabels?: LawLabel[]
   effects(data: BaseParams, startYear: number, currentYear: number): Partial<BaseParams>
 }
 


### PR DESCRIPTION
Das Gesetz "KernenergieVerlängern" entfernt "InitialAtomausstieg" aus den `acceptedLaws`. Das passiert aber nur über die LawLabel.

Nur die letzten 2 Commits gehören dazu...