### PR TITLE
Explicit units; Popularity corrected; Range checks; Two new laws.

### DIFF
--- a/src/events/social-media.ts
+++ b/src/events/social-media.ts
@@ -1,4 +1,5 @@
 import { createEvent } from "../Factory"
+import { Percent } from "../types"
 
 export default createEvent({
   title: "Social Media Alarm!",
@@ -8,8 +9,9 @@ export default createEvent({
   `,
 
   apply(context) {
-    if (context.state.game) {
-      context.state.game.values.popularity -= 20
+    const g = context.state.game
+    if (g) {
+      g.values.popularity += Math.max(-g.values.popularity, -20 as Percent)
     }
   },
 

--- a/src/laws/DaemmungVonWohngebaeudenFoerdern.ts
+++ b/src/laws/DaemmungVonWohngebaeudenFoerdern.ts
@@ -1,0 +1,24 @@
+import { LawDefinition, MioTons, MrdEuro, Percent, WritableBaseParams } from "../types"
+
+export default {
+  title: "Dämmung von Wohngebäuden fördern",
+  description: "Die nachträgliche Dämmung von Wohngebäuden wird mit günstigen Krediten gefördert.",
+  effects(data, startYear, currentYear): Partial<WritableBaseParams> {
+    const costsPerYear: MrdEuro = 1
+    const yearsActive = currentYear - startYear
+    if (yearsActive >= 2) {
+      return {
+        stateDebt: costsPerYear,
+        co2emissionsBuildings: Math.max(-data.co2emissionsBuildings, -2 as MioTons),
+      }
+    } else {
+      return {
+        stateDebt: costsPerYear,
+      }
+    }
+  },
+  priority(game) {
+    const buildingsFraction = game.values.co2emissionsBuildings / game.values.co2emissions
+    return 1000 * (buildingsFraction - 0.15)
+  },
+} as LawDefinition

--- a/src/laws/EnergiemixRegeltDerMarkt.ts
+++ b/src/laws/EnergiemixRegeltDerMarkt.ts
@@ -1,5 +1,5 @@
 import { defaultValues } from "../repository"
-import { LawDefinition, WritableBaseParams } from "../types"
+import { LawDefinition, MrdEuro, TWh, WritableBaseParams } from "../types"
 
 export default {
   title: "Energiemix regelt der Markt",
@@ -7,12 +7,12 @@ export default {
 
   effects(data, startYear, currentYear): Partial<WritableBaseParams> {
     return {
-      stateDebt: -37,
-      electricityHardCoal: -Math.min(0.1 * defaultValues.electricityHardCoal, data.electricityHardCoal),
-      electricityBrownCoal: -Math.min(0.05 * defaultValues.electricityBrownCoal, data.electricityBrownCoal),
-      electricityWind: 5.0,
-      electricitySolar: 3.0,
-      electricityWater: 0.5,
+      stateDebt: -37 as MrdEuro,
+      electricityHardCoal: Math.max(-data.electricityHardCoal, -0.1 * defaultValues.electricityHardCoal),
+      electricityBrownCoal: Math.max(-data.electricityBrownCoal, -0.05 * defaultValues.electricityBrownCoal),
+      electricityWind: 5.0 as TWh,
+      electricitySolar: 3.0 as TWh,
+      electricityWater: 0.5 as TWh,
     }
   },
 

--- a/src/laws/FoerderungFuerTierhaltungAbschaffen.ts
+++ b/src/laws/FoerderungFuerTierhaltungAbschaffen.ts
@@ -1,4 +1,4 @@
-import { LawDefinition, WritableBaseParams } from "../types"
+import { LawDefinition, MioTons, MrdEuro, Percent, WritableBaseParams } from "../types"
 
 export default {
   title: "Förderung für Tierhaltung abschaffen",
@@ -7,13 +7,13 @@ export default {
   effects(data, startYear, currentYear): Partial<WritableBaseParams> {
     if (startYear === currentYear) {
       return {
-        co2emissionsAgriculture: -Math.min(data.co2emissionsAgriculture, 10),
-        stateDebt: -10,
-        popularity: -0.2 * data.popularity,
+        co2emissionsAgriculture: Math.max(-data.co2emissionsAgriculture, -10 as MioTons),
+        stateDebt: -10 as MrdEuro,
+        popularity: Math.max(-data.popularity, -20 as Percent),
       }
     } else {
       return {
-        stateDebt: -10,
+        stateDebt: -10 as MrdEuro,
       }
     }
   },

--- a/src/laws/InitialAtomausstieg.ts
+++ b/src/laws/InitialAtomausstieg.ts
@@ -1,4 +1,4 @@
-import { LawDefinition, WritableBaseParams } from "../types"
+import { LawDefinition, TWh, WritableBaseParams } from "../types"
 
 export default {
   title: "Initial: Atomausstieg",
@@ -7,8 +7,8 @@ export default {
 
   effects(data, startYear, currentYear): Partial<WritableBaseParams> {
     const mapping: Record<number, number> = {
-      2021: 60.45,
-      2022: 30.21,
+      2021: 60.45 as TWh,
+      2022: 30.21 as TWh,
     }
     const newValue = mapping[currentYear] || 0
     return {

--- a/src/laws/KernenergienutzungVerlaengern.ts
+++ b/src/laws/KernenergienutzungVerlaengern.ts
@@ -1,4 +1,4 @@
-import { LawDefinition, WritableBaseParams } from "../types"
+import { LawDefinition, MrdEuro, Percent, TWh, WritableBaseParams } from "../types"
 
 export default {
   title: "Kernenergienutzung verlängern",
@@ -7,15 +7,15 @@ export default {
 
   effects(data, startYear, currentYear): Partial<WritableBaseParams> {
     return {
-      electricityNuclear: 104.3 - data.electricityNuclear,
-      stateDebt: -2.5, // Mrd €
-      popularity: -data.popularity * 0.04,
+      electricityNuclear: (104.3 as TWh) - data.electricityNuclear,
+      stateDebt: -2.5 as MrdEuro,
+      popularity: Math.max(-data.popularity, -4 as Percent),
     }
   },
 
   priority(game) {
     // More likely if lots of Gas usage leads to dependency of Russia etc..
-    const electricityGasAtStart = 56.77 // TODO: Put constants in central place
+    const electricityGasAtStart: TWh = 56.77 // TODO: Put constants in central place
     const gasChangeRelStart = game.values.electricityGas - electricityGasAtStart
     return (1000 * gasChangeRelStart) / electricityGasAtStart
   },

--- a/src/laws/NahverkehrAusbauen.ts
+++ b/src/laws/NahverkehrAusbauen.ts
@@ -1,0 +1,25 @@
+import { LawDefinition, MioTons, MrdEuro, Percent, WritableBaseParams } from "../types"
+
+export default {
+  title: "Nahverkehr Ausbauen",
+  description: "Der Ausbau des Nahverkehrs wird bundesweit stärker bezuschusst.",
+  effects(data, startYear, currentYear): Partial<WritableBaseParams> {
+    const costsPerYear: MrdEuro = 3
+    const yearsActive = currentYear - startYear
+    if (yearsActive >= 5) {
+      return {
+        stateDebt: costsPerYear,
+        co2emissionsMobility: Math.max(-data.co2emissionsMobility, -2 as MioTons),
+        popularity: Math.min(100 - data.popularity, 2 as Percent),
+      }
+    } else {
+      return {
+        stateDebt: costsPerYear,
+      }
+    }
+  },
+  priority(game) {
+    const mobilityFraction = game.values.co2emissionsMobility / game.values.co2emissions
+    return 1000 * (mobilityFraction - 0.25)
+  },
+} as LawDefinition

--- a/src/laws/WindenergieSubventionieren.sync-conflict-20210526-174521-E5FCSHR.ts
+++ b/src/laws/WindenergieSubventionieren.sync-conflict-20210526-174521-E5FCSHR.ts
@@ -1,0 +1,24 @@
+import { LawDefinition, MrdEuro, TWh, WritableBaseParams } from "../types"
+
+export default {
+  title: "Windenergie subventionieren",
+  description: "Garantierte Einspeisevergütung für neue und erneuterte Windanlagen",
+
+  effects(data, startYear, currentYear): Partial<WritableBaseParams> {
+    return {
+      electricityWind: 20 as TWh,
+      stateDebt: 1 as MrdEuro,
+    }
+  },
+
+  priority(game) {
+    const electricityNonRenewable =
+      game.values.electricityDemand -
+      game.values.electricityWind -
+      game.values.electricitySolar -
+      game.values.electricityWater -
+      game.values.electricityBiomass
+    const ratio = electricityNonRenewable / game.values.electricityDemand
+    return 100 * ratio
+  },
+} as LawDefinition

--- a/src/laws/index.ts
+++ b/src/laws/index.ts
@@ -2,17 +2,21 @@ import { createLaw } from "../Factory"
 import KohleverstromungEinstellen from "./KohleverstromungEinstellen"
 import EnergiemixRegeltDerMarkt from "./EnergiemixRegeltDerMarkt"
 import KernenergienutzungVerlaengern from "./KernenergienutzungVerlaengern"
-import WindenergieSubventionieren from "./WindenergieSubventionieren"
 import InitialAtomausstieg from "./InitialAtomausstieg"
+import WindenergieSubventionieren from "./WindenergieSubventionieren"
+import DaemmungVonWohngebaeudenFoerdern from "./DaemmungVonWohngebaeudenFoerdern"
+import NahverkehrAusbauen from "./NahverkehrAusbauen"
 import FoerderungFuerTierhaltungAbschaffen from "./FoerderungFuerTierhaltungAbschaffen"
 
 export const allLaws = Object.entries({
   KohleverstromungEinstellen,
   EnergiemixRegeltDerMarkt,
   KernenergienutzungVerlaengern,
-  WindenergieSubventionieren,
-  FoerderungFuerTierhaltungAbschaffen,
   InitialAtomausstieg,
+  WindenergieSubventionieren,
+  DaemmungVonWohngebaeudenFoerdern,
+  NahverkehrAusbauen,
+  FoerderungFuerTierhaltungAbschaffen,
 }).map(([name, module]) => {
   return createLaw(name, module)
 })


### PR DESCRIPTION
Bin gespannt, ob Du das mit den Typen für die Einheiten gut findest. Richtig gut wäre es, wenn die auch abgeprüft werden würden - aber ich vermute, dass das nicht geht, wenn alles eigentlich `number` ist. In Java/C++ müsste man Wrapper-Klassen schreiben. Nicht schön.

Die Range Checks in den Laws wären eigentlich besser bei der Definition der Parameter untergebracht. Schon wieder ein Grund für Wrapper Klassen?