### PR TITLE
Fixed switch to next year

### DIFF
--- a/src/EventMachine.ts
+++ b/src/EventMachine.ts
@@ -6,9 +6,14 @@ export type PriorizedEvent = Event & { priority: number }
 export default function EventMachine(store: Store, allEvents: Event[], random = Math.random) {
   let timer: unknown // to work with both, NodeJS and browser
 
+  function getPriority(event: Event): number {
+    const probability = event.probability(store)
+    return probability >= random() ? probability : 0
+  }
+
   function getPriorizedEvents(): PriorizedEvent[] {
     return allEvents
-      .map((event) => ({ ...event, priority: event.probability(store) * random() }))
+      .map((event) => ({ ...event, priority: getPriority(event) }))
       .filter((event) => event.priority)
       .sort((a, b) => b.priority - a.priority)
   }

--- a/src/components/GameSetup.vue
+++ b/src/components/GameSetup.vue
@@ -14,6 +14,7 @@ export default defineComponent({
   data() {
     const store = useStore()
     return {
+      store,
       devMode: import.meta.env.DEV || localStorage.getItem("devMode") === "true",
       eventMachine: EventMachine(store, allEvents),
     }
@@ -30,6 +31,14 @@ export default defineComponent({
 
     priorizedEvents(): PriorizedEvent[] {
       return this.eventMachine.getPriorizedEvents()
+    },
+
+    probability(): (event: Event) => string {
+      return (event) => (event.probability(this.store) * 100).toFixed(2)
+    },
+
+    currentYear(): number {
+      return this.store.state.game?.currentYear || 2021
     },
   },
 
@@ -51,9 +60,11 @@ export default defineComponent({
   <div class="game-setup">
     <img src="../assets/background.jpg" />
 
+    <div id="year">{{ currentYear }}</div>
     <LawProposals />
     <SpeechBubble :title="eventTitle" :text="eventText" @acknowledge="acknowledge" />
   </div>
+
   <div class="peek">
     <PeekInside v-if="devMode" />
   </div>
@@ -63,6 +74,7 @@ export default defineComponent({
     <ul v-if="devMode && $store.state.game">
       <li v-for="event in priorizedEvents" :key="event.id">
         <span>{{ event.title }}</span>
+        <span>{{ probability(event) }}%</span>
         <span>{{ (event.priority * 100).toFixed(2) }}%</span>
       </li>
     </ul>
@@ -84,6 +96,26 @@ export default defineComponent({
 
   > img {
     max-height: calc(100vh - 4rem);
+  }
+
+  #year {
+    position: absolute;
+    top: 42%;
+    left: 47%;
+    font-size: 1.4vw;
+    border: 1px solid black;
+    padding: 2em 0.5em 0;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      right: 3px;
+      height: 1.7em;
+      border: 1px solid black;
+      box-sizing: border-box;
+    }
   }
 }
 
@@ -117,8 +149,12 @@ export default defineComponent({
       width: 100%;
       justify-content: space-between;
 
-      span:last-of-type {
-        padding-left: 10px;
+      span {
+        padding: 0 5px;
+      }
+
+      span:first-of-type {
+        flex-grow: 1;
       }
     }
   }

--- a/src/events/NewYear.ts
+++ b/src/events/NewYear.ts
@@ -1,4 +1,5 @@
 import { defineEvent } from "../Factory"
+import { getAcceptedLaw } from "../LawProposer"
 
 export default defineEvent({
   title: "Happy New Year!",
@@ -13,12 +14,17 @@ export default defineEvent({
 
   probability(store) {
     const game = store.state.game
-    const amountOfLaws = game?.acceptedLaws.filter((law) => law.effectiveSince == game.currentYear).length || 0
-    if (amountOfLaws < 3 ) {
+    const acceptedLaws = game?.acceptedLaws
+      .map(getAcceptedLaw)
+      .filter((law) => !law.labels?.includes("initial") && law.effectiveSince == game.currentYear + 1)
+
+    const numOfLaws = acceptedLaws && acceptedLaws.length || 0
+    if (numOfLaws < 3) {
       return 0
     }
+
     // After 3 decisions, the year might end, after 5 decisions, the probability is 100%
-    const probability = amountOfLaws * 0.1 + 0.5
-    return Math.max(Math.random() + probability)
+    const probability = Math.round((numOfLaws - 2) * 33.3) / 100
+    return Math.min(1, probability)
   },
 })

--- a/src/events/SocialMedia.ts
+++ b/src/events/SocialMedia.ts
@@ -1,4 +1,5 @@
 import { defineEvent } from "../Factory"
+import { Game } from "../game"
 import { Percent } from "../types"
 
 export default defineEvent({
@@ -9,9 +10,10 @@ export default defineEvent({
   `,
 
   apply(context) {
-    const g = context.state.game
-    if (g) {
-      g.values.popularity += Math.max(-g.values.popularity, -20 as Percent)
+    const game = { ...context.state.game } as Game
+    if (game) {
+      game.values.popularity += Math.max(-game.values.popularity, -20 as Percent)
+      context.commit("setGameState", { game })
     }
   },
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -81,7 +81,6 @@ export const actions = {
   },
 
   async applyEvent(context: Context, payload: { event: Event }) {
-    payload.event.apply(context)
     const game = { ...(context.state.game as Game) }
     game.events.unshift(payload.event)
     await repository.eventOccurred(game, payload.event)
@@ -89,6 +88,7 @@ export const actions = {
       game.proposedLaws = payload.event.laws.map(law => law.id)
     }
     context.commit("setGameState", { game })
+    payload.event.apply(context)
   },
 
   acknowledgeEvent(context: Context, event: Event) {


### PR DESCRIPTION
Advancing to the next year didn't work correctly due to the fact that after the event dispatched the `advanceYear` action, the event itself was saved, but with the previously copied state.

Counting the accepted laws to decide if the year should be advanced, is also fixed.