### PR TITLE
Create events from markdown

### DIFF
--- a/events/Altbausanierung.md
+++ b/events/Altbausanierung.md
@@ -1,0 +1,18 @@
+# Gesetzesinitiative zur Sanierung von Altbauten
+
+Zur Einhaltung der Pariser Klimaschutzvereinbarung halten Experten es für unausweichlich, dass in die Sanierung von Altbauten investiert werden muss. Die konkrete Ausgestaltung wird kontrovers diskutiert.
+
+## laws
+
+- DaemmungAltbauAbschaffen
+- AllesBleibtBeimAlten
+- DaemmungAltbau1Percent
+- DaemmungAltbau2Percent
+- DaemmungAltbau4Percent
+
+## probability
+
+```typescript
+const buildingsPercentage = (game.values.co2emissionsBuildings / game.values.co2emissions) * 100
+return linear(15, 25, buildingsPercentage) / 100
+```

--- a/events/bestechung.md
+++ b/events/bestechung.md
@@ -1,0 +1,34 @@
+# Anruf von befreundetem Unternehmer
+
+Klaus, ein Unternehmer, den du auf einer Dienstreise kennen gelernt hast, ruft an und möchte dich in seine
+Ferienvilla auf Sardinien einladen. Er verlässt sich natürlich darauf, dass du dem Gesetzentwurf zum Abbau
+von Subventionen nicht zustimmen wirst.
+
+## apply
+
+```typescript
+const game = context.state.game
+if (!game) {
+  return
+}
+const law = getFirstMatchingLaw(idsToLaws(game.proposedLaws))
+if (law) {
+  context.dispatch("rejectLaw", { lawId: law.id })
+}
+```
+
+## probability
+
+```typescript
+const law = getFirstMatchingLaw(idsToLaws(game.proposedLaws))
+return law ? Math.random() : 0
+```
+
+## functions
+
+```typescript
+// if proposed laws contain at least one with the words 'subvention' and 'abbau', this event might occur
+function getFirstMatchingLaw(proposedLaws: Law[]) {
+  return proposedLaws.find((law) => law.title.match(/subvention/i) && law.title.match(/abbau/i))
+}
+```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development vite",
     "test": "nyc mocha",
+    "prebuild": "esbuild --bundle --platform=node --sourcemap src/generate.ts | node && npx prettier -w src/events/*",
     "build": "vue-tsc --noEmit && vite build && npm run server:build && npm run copy-sources",
     "serve": "vite preview",
     "start": "cross-env NODE_ENV=production node dist/server.js",

--- a/src/events/Altbausanierung.ts
+++ b/src/events/Altbausanierung.ts
@@ -1,10 +1,12 @@
 import { defineEvent } from "../Factory"
 import { linear } from "../lawTools"
+import { idsToLaws, Law } from "../laws"
 
 export default defineEvent({
   title: "Gesetzesinitiative zur Sanierung von Altbauten",
   description:
     "Zur Einhaltung der Pariser Klimaschutzvereinbarung halten Experten es für unausweichlich, dass in die Sanierung von Altbauten investiert werden muss. Die konkrete Ausgestaltung wird kontrovers diskutiert.",
+
   laws: [
     "DaemmungAltbauAbschaffen",
     "AllesBleibtBeimAlten",
@@ -13,7 +15,7 @@ export default defineEvent({
     "DaemmungAltbau4Percent",
   ],
 
-  apply() {},
+  apply(context) {},
 
   probability(game) {
     const buildingsPercentage = (game.values.co2emissionsBuildings / game.values.co2emissions) * 100

--- a/src/events/bestechung.ts
+++ b/src/events/bestechung.ts
@@ -1,4 +1,5 @@
 import { defineEvent } from "../Factory"
+import { linear } from "../lawTools"
 import { idsToLaws, Law } from "../laws"
 
 // if proposed laws contain at least one with the words 'subvention' and 'abbau', this event might occur
@@ -8,10 +9,10 @@ function getFirstMatchingLaw(proposedLaws: Law[]) {
 
 export default defineEvent({
   title: "Anruf von befreundetem Unternehmer",
-  description: `Klaus, ein Unternehmer, den du auf einer Dienstreise kennen gelernt hast, ruft an und möchte dich in seine
-    Ferienvilla auf Sardinien einladen. Er verlässt sich natürlich darauf, dass du dem Gesetzentwurf zum Abbau von Subventionen
-    nicht zustimmen wirst.
-  `,
+  description:
+    "Klaus, ein Unternehmer, den du auf einer Dienstreise kennen gelernt hast, ruft an und möchte dich in seine Ferienvilla auf Sardinien einladen. Er verlässt sich natürlich darauf, dass du dem Gesetzentwurf zum Abbau von Subventionen nicht zustimmen wirst.",
+
+  laws: [],
 
   apply(context) {
     const game = context.state.game

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,0 +1,54 @@
+import fs from "fs"
+import path from "path"
+
+const eventsDir = path.resolve(__dirname, "src", "events")
+
+const template = `import { defineEvent } from "../Factory"
+import { linear } from "../lawTools"
+import { idsToLaws, Law } from "../laws"
+{{functions}}
+export default defineEvent({
+  title: "{{title}}",
+  description:
+    "{{description}}",
+
+  laws: [{{laws}}],
+
+  apply(context) {{{apply}}},
+
+  probability(game) {{{probability}}},
+})
+`
+
+function generateEvent(content: string): string {
+  const parts = content.split(/#(.*?)\n/g)
+  const vars = {
+    title: parts[1].trim(),
+    description: parts[2].replace(/\n/g, " ").trim(),
+    laws: "",
+    apply: "",
+    probability: "return Math.random()",
+    functions: "",
+  }
+  for (let i = 3; i < parts.length; i += 2) {
+    const title = parts[i].replace(/^#/, "").trim()
+    if (vars[title as keyof typeof vars] === undefined) {
+      throw new Error(`Unknown sub title: ${title}`)
+    }
+    const value = parts[i + 1].trim()
+    if (title === "laws") {
+      vars.laws += "\n" + value.split(/\n/).filter(e => e).map(e => `    "${e.replace(/-/, "").trim()}",`).join("\n") + "\n  "
+    } else {
+      const cleanedValue = value.split("\n").filter(e => !e.match(/^```/)).map(e => `    ${e}`).join("\n")
+      vars[title as keyof typeof vars] = "\n" + cleanedValue + "\n  "
+    }
+  }
+  return template.replace(/{{(\w+)}}/gs, (match, key: keyof typeof vars) => vars[key])
+}
+
+fs.readdirSync(path.resolve(__dirname, "events")).forEach((file) => {
+  if (file.match(/.md$/)) {
+    const generated = generateEvent(fs.readFileSync(path.resolve("events", file)).toString())
+    fs.writeFileSync(path.join(eventsDir, file.replace(".md", ".ts")), generated)
+  }
+})


### PR DESCRIPTION
I want to make editing events even easier, so I've added a `prebuild` npm target which takes markdown files from `/events` and creates a event definition file.

What do you think, @mdrie ? If you like the idea, I would convert all existing events to markdown.