### PR TITLE
Extend event interface to allow certain events like NewYear to trigger immediately

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
+import { Ratio } from "./types"
+
 export const startYear = 2021
 export const endYear = 2050
 export const maxProposedLaws = 6
+export const probabilityThatEventOccurs: Ratio = 0.6

--- a/src/events/Altbausanierung.ts
+++ b/src/events/Altbausanierung.ts
@@ -17,6 +17,6 @@ export default defineEvent({
 
   probability(game) {
     const buildingsPercentage = (game.values.co2emissionsBuildings / game.values.co2emissions) * 100
-    return linear(15, 25, buildingsPercentage) / 100
+    return Math.max(1, linear(15, 25, buildingsPercentage) / 100)
   },
 })

--- a/src/events/EventsTypes.ts
+++ b/src/events/EventsTypes.ts
@@ -1,17 +1,47 @@
 import { LawId } from "../laws"
 import { Citations } from "../citations"
 import { Context } from "../store"
-import { Details, Internals, Percent } from "../types"
+import { Details, Internals, Ratio } from "../types"
 import { Game } from "../game"
 
 export type EventDefinition = {
   title: string
   description: string
   apply(context: Context): void
-  probability(game: Game): Percent
+  /** A value used to determine if this event occurs now.
+   *
+   * Three possible values and their meanings are
+   * - Zero or less: The event may not occur now.
+   * - Larger 1: The event occurs now.
+   * - Between 0 and 1: Probability that the event occurs relative to others.
+   *
+   * Events will be processed as follows:
+   * - If some events return > 1, the one with the highest value will occur, otherwise
+   * - with a probability of {@link probabilityThatEventOccurs} no event occurs, otherwise
+   * - one of the events which returned a value between 0 and 1 occurs with its relative probability.
+   *
+   * The values returned by events (which returned between 0 and 1) may add to any value.
+   * An event returning a very large value will effectively reduce the probabilities of
+   * all other events. This means that an event returning 0.9 will most likely not occur
+   * with a probability of 90%, since other events (and {@link probabilityThatEventOccurs})
+   * will effectively reduce it.
+   * However, an event returning 0.9 will occur 9 times as often as an event returning 0.1.
+   *
+   * @param game The game data to use for determining the probability.
+   * @return The probability as described in the summary.
+   */
+  probability(game: Game): Ratio
   acknowledged?: boolean
   laws?: LawId[]
   citations?: Citations // TODO #79: Make mandatory
   details?: Details // TODO #79: Make mandatory
   internals?: Internals // TODO #79: Make mandatory
+}
+
+export const eventProbs = {
+  newYear: 2,
+  won: 3,
+  broke: 4,
+  lostElection: 5,
+  co2BudgetUsed: 6,
 }

--- a/src/events/EventsTypes.ts
+++ b/src/events/EventsTypes.ts
@@ -10,10 +10,14 @@ export type EventDefinition = {
   apply(context: Context): void
   /** A value used to determine if this event occurs now.
    *
-   * Three possible values and their meanings are
+   * Three possible values-ranges and their meanings are
    * - Zero or less: The event may not occur now.
    * - Larger 1: The event occurs now.
    * - Between 0 and 1: Probability that the event occurs relative to others.
+   *
+   * Values larger than one shall only be those defined by {@link specialEventProbs}.
+   *
+   * @remarks
    *
    * Events will be processed as follows:
    * - If some events return > 1, the one with the highest value will occur, otherwise
@@ -38,10 +42,18 @@ export type EventDefinition = {
   internals?: Internals // TODO #79: Make mandatory
 }
 
-export const eventProbs = {
+/** The used special return values of {@link EventDefinition.probability} > 1.
+ *
+ * @remarks
+ *
+ * The names correspond to the events returning them.
+ *
+ * The values define the priority in case several may occur at the same time.
+ */
+export const specialEventProbs = {
   newYear: 2,
-  won: 3,
-  broke: 4,
-  lostElection: 5,
-  co2BudgetUsed: 6,
+  timesUp: 3,
+  finanzKollaps: 4,
+  wahlVerloren: 5,
+  hitzehoelle: 6,
 }

--- a/src/events/Finanzkollaps.ts
+++ b/src/events/Finanzkollaps.ts
@@ -1,6 +1,6 @@
 import { defineEvent } from "../Factory"
 import { defaultValues } from "../params"
-import { eventProbs } from "./EventsTypes"
+import { specialEventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Zusammenbruch des Finanzsystems",
@@ -14,6 +14,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.stateDebt > defaultValues.stateDebt * 2 ? eventProbs.broke : 0
+    return game.values.stateDebt > defaultValues.stateDebt * 2 ? specialEventProbs.finanzKollaps : 0
   },
 })

--- a/src/events/Finanzkollaps.ts
+++ b/src/events/Finanzkollaps.ts
@@ -1,6 +1,6 @@
 import { defineEvent } from "../Factory"
-import { Game } from "../game"
 import { defaultValues } from "../params"
+import { eventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Zusammenbruch des Finanzsystems",
@@ -14,6 +14,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.stateDebt > defaultValues.stateDebt * 2 ? 1 : 0
+    return game.values.stateDebt > defaultValues.stateDebt * 2 ? eventProbs.broke : 0
   },
 })

--- a/src/events/Hitzehölle.ts
+++ b/src/events/Hitzehölle.ts
@@ -1,4 +1,5 @@
 import { defineEvent } from "../Factory"
+import { eventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Hitzehölle",
@@ -12,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.co2budget <= 0 ? 1 : 0
+    return game.values.co2budget <= 0 ? eventProbs.co2BudgetUsed : 0
   },
 })

--- a/src/events/Hitzehölle.ts
+++ b/src/events/Hitzehölle.ts
@@ -1,5 +1,5 @@
 import { defineEvent } from "../Factory"
-import { eventProbs } from "./EventsTypes"
+import { specialEventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Hitzehölle",
@@ -13,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.co2budget <= 0 ? eventProbs.co2BudgetUsed : 0
+    return game.values.co2budget <= 0 ? specialEventProbs.hitzehoelle : 0
   },
 })

--- a/src/events/NewYear.ts
+++ b/src/events/NewYear.ts
@@ -1,6 +1,6 @@
 import { defineEvent } from "../Factory"
 import { getAcceptedLaw } from "../laws"
-import { eventProbs } from "./EventsTypes"
+import { specialEventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Happy New Year!",
@@ -22,8 +22,8 @@ export default defineEvent({
     if (numOfLaws < 3) {
       return 0
     }
-    if (numOfLaws > 4) {
-      return eventProbs.newYear
+    if (numOfLaws >= 5) {
+      return specialEventProbs.newYear
     }
 
     // After 3 decisions, the year might end, after 5 decisions, the probability is 100%

--- a/src/events/NewYear.ts
+++ b/src/events/NewYear.ts
@@ -1,5 +1,6 @@
 import { defineEvent } from "../Factory"
 import { getAcceptedLaw } from "../laws"
+import { eventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Happy New Year!",
@@ -20,6 +21,9 @@ export default defineEvent({
     const numOfLaws = (acceptedLaws && acceptedLaws.length) || 0
     if (numOfLaws < 3) {
       return 0
+    }
+    if (numOfLaws > 4) {
+      return eventProbs.newYear
     }
 
     // After 3 decisions, the year might end, after 5 decisions, the probability is 100%

--- a/src/events/TimesUp.ts
+++ b/src/events/TimesUp.ts
@@ -1,5 +1,5 @@
 import { defineEvent } from "../Factory"
-import { eventProbs } from "./EventsTypes"
+import { specialEventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Du hast durchgehalten",
@@ -13,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.currentYear === 2050 ? eventProbs.won : 0
+    return game.currentYear === 2050 ? specialEventProbs.timesUp : 0
   },
 })

--- a/src/events/TimesUp.ts
+++ b/src/events/TimesUp.ts
@@ -1,4 +1,5 @@
 import { defineEvent } from "../Factory"
+import { eventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Du hast durchgehalten",
@@ -12,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.currentYear === 2050 ? 1 : 0
+    return game.currentYear === 2050 ? eventProbs.won : 0
   },
 })

--- a/src/events/WahlVerloren.ts
+++ b/src/events/WahlVerloren.ts
@@ -1,5 +1,5 @@
 import { defineEvent } from "../Factory"
-import { Store } from "../store"
+import { eventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Wahl verloren",
@@ -13,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.popularity <= 0 ? 1 : 0
+    return game.values.popularity <= 0 ? eventProbs.lostElection : 0
   },
 })

--- a/src/events/WahlVerloren.ts
+++ b/src/events/WahlVerloren.ts
@@ -1,5 +1,5 @@
 import { defineEvent } from "../Factory"
-import { eventProbs } from "./EventsTypes"
+import { specialEventProbs } from "./EventsTypes"
 
 export default defineEvent({
   title: "Wahl verloren",
@@ -13,6 +13,6 @@ export default defineEvent({
   },
 
   probability(game) {
-    return game.values.popularity <= 0 ? eventProbs.lostElection : 0
+    return game.values.popularity <= 0 ? specialEventProbs.wahlVerloren : 0
   },
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,9 @@ export type MioTons = number
 export type TWh = number
 export type MrdEuro = number
 export type TsdPeople = number
+/** A number between 0 and 100. Divide by 100 to get {@link Ratio}. */
 export type Percent = number
+/** A number between 0 and 1. Multiply with 100 to get {@link Percent}. */
+export type Ratio = number
 export type GramPerPsgrKm = number
 export type MioPsgrKm = number


### PR DESCRIPTION
I started again writing laws and noticed that testing is not really possibly, because NewYear is not triggered often enough.

Also note the previous commit on the "main" branch. Before that, the proposed laws were not updated correctly and eventually there were no laws to select. I commited that on "main", because it was sooo small.